### PR TITLE
Commit with reason for the refactored code

### DIFF
--- a/DevTest2/DevTest2/Controllers/HomeController.vb
+++ b/DevTest2/DevTest2/Controllers/HomeController.vb
@@ -1,4 +1,6 @@
-﻿Public Class HomeController
+﻿Imports System.Data.Entity
+
+Public Class HomeController
     Inherits System.Web.Mvc.Controller
 
     Function Index() As ActionResult
@@ -7,37 +9,24 @@
     End Function
 
     Function CsvReport() As ActionResult
-
-        Response.ContentType = "text/plain"
-        Response.Write("CustomerId, Name, OrderCount, SalesTotal" & vbCr)
-
+        Dim SalesTotalInfo As StringBuilder = New StringBuilder()
+        'Response.ContentType = "text/plain"
+        'Response.Write("CustomerId, Name, OrderCount, SalesTotal" & vbCr)
+        SalesTotalInfo.Append("CustomerId, Name, OrderCount, SalesTotal" & vbCr)
         Using db As New AppDbContext()
 
             'get customers
-            Dim customers = From c In db.Customers
-                            Order By c.CustomerId
-                            Select c
+            Dim customers = (From c In db.Customers
+                             Order By c.CustomerId
+                             Select New With {c, c.Orders.Count, c.Orders.Select(Function(x) x.SalesTotal).Sum()}).ToList() ', c.Orders.Count()
 
-            For Each c In customers
-                Response.Write(String.Format("{0}, {1}, ", c.CustomerId, c.Name))
-
-                'get orders
-                Dim orders = From o In db.Orders
-                             Where o.Customer.CustomerId = c.CustomerId
-                             Select o
-
-                Dim orderCount As Integer = 0
-                Dim salesTotal As Decimal = 0
-                For Each o In orders
-                    orderCount += 1
-                    salesTotal += o.SalesTotal
-                Next
-
-                Response.Write(String.Format("{0}, {1}", orderCount, salesTotal.ToString("0.##")) & vbCr)
+            For Each cust In customers
+                SalesTotalInfo.Append(String.Format("{0}, {1}, {2}, {3}", cust.c.CustomerId, cust.c.Name, cust.Count, cust.Sum.ToString("0.##") & vbCr))
             Next
 
         End Using
-
+        Response.ContentType = "text/plain"
+        Response.Write(SalesTotalInfo)
         Response.End()
 
         Return Nothing

--- a/DevTest2/DevTest2/DevTest2.vbproj
+++ b/DevTest2/DevTest2/DevTest2.vbproj
@@ -58,6 +58,9 @@
     <Reference Include="Faker, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Faker.1.2\lib\Faker.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
@@ -132,9 +135,6 @@
     </Reference>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation">
       <HintPath>..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.0\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">
-      <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/DevTest2/DevTest2/Web.config
+++ b/DevTest2/DevTest2/Web.config
@@ -63,12 +63,6 @@
     </modules>
     <validation validateIntegratedModeConfiguration="false" />
   </system.webServer>
-  <system.codedom>
-    <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
-      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
-    </compilers>
-  </system.codedom>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
       <parameters>
@@ -79,4 +73,10 @@
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
+  <system.codedom>
+    <compilers>
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+    </compilers>
+  </system.codedom>
 </configuration>


### PR DESCRIPTION
Changed the type of SalesTotalInfo from string to StringBuilder. Explanation is same as above.
Moved the count and sales total sum into the same linq query where we get customer details. Getting all the data in one single linq query will reduce the time to get data instead of connecting to database multiple times.
Instead of writing response to web page for each record or each loop, all the data is appended to a SalesTotalInfo object and final string is written to webpage. This saves write time.